### PR TITLE
Хованский Дмитрий. Задача 3. Вариант 7. Вычисление многомерных интегралов с использованием многошаговой схемы (метод прямоугольников).

### DIFF
--- a/tasks/mpi/khovansky_d_rectangles_integral/func_tests/main.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/func_tests/main.cpp
@@ -21,14 +21,21 @@ TEST(khovansky_d_rectangles_integral_mpi, test_integral_x) {
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
-    task_data_mpi->inputs_count.emplace_back(bounds.size());
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
-    task_data_mpi->inputs_count.emplace_back(1);
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
-    task_data_mpi->inputs_count.emplace_back(1);
-    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
-    task_data_mpi->outputs_count.emplace_back(1);
+      std::vector<uint8_t> bounds_data(sizeof(std::pair<double, double>) * bounds.size());
+      std::memcpy(bounds_data.data(), bounds.data(), bounds_data.size());
+      task_data_mpi->inputs.emplace_back(bounds_data.data());
+      task_data_mpi->inputs_count.emplace_back(bounds.size());
+
+      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+      task_data_mpi->inputs_count.emplace_back(1);
+
+      std::vector<uint8_t> func_data(sizeof(std::function<double(std::vector<double>)>));
+      std::memcpy(func_data.data(), func_ptr.get(), sizeof(std::function<double(std::vector<double>)>));
+      task_data_mpi->inputs.emplace_back(func_data.data());
+      task_data_mpi->inputs_count.emplace_back(func_data.size());
+
+      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+      task_data_mpi->outputs_count.emplace_back(1);
   }
 
   khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi rectangles_integral(task_data_mpi);
@@ -38,7 +45,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_integral_x) {
   rectangles_integral.PostProcessingImpl();
 
   if (world.rank() == 0) {
-    ASSERT_NEAR(result, 0.5, tolerance);
+      ASSERT_NEAR(result, 0.5, tolerance);
   }
 }
 
@@ -53,12 +60,19 @@ TEST(khovansky_d_rectangles_integral_mpi, test_multidimensional_integral_xy) {
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+    std::vector<uint8_t> bounds_data(sizeof(std::pair<double, double>) * bounds.size());
+    std::memcpy(bounds_data.data(), bounds.data(), bounds_data.size());
+    task_data_mpi->inputs.emplace_back(bounds_data.data());
     task_data_mpi->inputs_count.emplace_back(bounds.size());
+
     task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
     task_data_mpi->inputs_count.emplace_back(1);
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
-    task_data_mpi->inputs_count.emplace_back(1);
+
+    std::vector<uint8_t> func_data(sizeof(std::function<double(std::vector<double>)>));
+    std::memcpy(func_data.data(), func_ptr.get(), sizeof(std::function<double(std::vector<double>)>));
+    task_data_mpi->inputs.emplace_back(func_data.data());
+    task_data_mpi->inputs_count.emplace_back(func_data.size());
+
     task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
     task_data_mpi->outputs_count.emplace_back(1);
   }
@@ -85,12 +99,19 @@ TEST(khovansky_d_rectangles_integral_mpi, test_multidimensional_integral_xyz) {
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+    std::vector<uint8_t> bounds_data(sizeof(std::pair<double, double>) * bounds.size());
+    std::memcpy(bounds_data.data(), bounds.data(), bounds_data.size());
+    task_data_mpi->inputs.emplace_back(bounds_data.data());
     task_data_mpi->inputs_count.emplace_back(bounds.size());
+
     task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
     task_data_mpi->inputs_count.emplace_back(1);
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
-    task_data_mpi->inputs_count.emplace_back(1);
+
+    std::vector<uint8_t> func_data(sizeof(std::function<double(std::vector<double>)>));
+    std::memcpy(func_data.data(), func_ptr.get(), sizeof(std::function<double(std::vector<double>)>));
+    task_data_mpi->inputs.emplace_back(func_data.data());
+    task_data_mpi->inputs_count.emplace_back(func_data.size());
+
     task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
     task_data_mpi->outputs_count.emplace_back(1);
   }
@@ -117,12 +138,19 @@ TEST(khovansky_d_rectangles_integral_mpi, test_integral_sum) {
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+    std::vector<uint8_t> bounds_data(sizeof(std::pair<double, double>) * bounds.size());
+    std::memcpy(bounds_data.data(), bounds.data(), bounds_data.size());
+    task_data_mpi->inputs.emplace_back(bounds_data.data());
     task_data_mpi->inputs_count.emplace_back(bounds.size());
+
     task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
     task_data_mpi->inputs_count.emplace_back(1);
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
-    task_data_mpi->inputs_count.emplace_back(1);
+
+    std::vector<uint8_t> func_data(sizeof(std::function<double(std::vector<double>)>));
+    std::memcpy(func_data.data(), func_ptr.get(), sizeof(std::function<double(std::vector<double>)>));
+    task_data_mpi->inputs.emplace_back(func_data.data());
+    task_data_mpi->inputs_count.emplace_back(func_data.size());
+
     task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
     task_data_mpi->outputs_count.emplace_back(1);
   }

--- a/tasks/mpi/khovansky_d_rectangles_integral/func_tests/main.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/func_tests/main.cpp
@@ -1,0 +1,169 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "mpi/khovansky_d_rectangles_integral/include/ops_mpi.hpp"
+
+TEST(khovansky_d_rectangles_integral_mpi, test_integral_x) {
+  boost::mpi::communicator world;
+  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}};
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        return args[0];
+      });
+
+  auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+    task_data_mpi->inputs_count.emplace_back(bounds.size());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+    task_data_mpi->outputs_count.emplace_back(1);
+  }
+
+  khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi rectangles_integral(task_data_mpi);
+  ASSERT_EQ(rectangles_integral.ValidationImpl(), true);
+  rectangles_integral.PreProcessingImpl();
+  rectangles_integral.RunImpl();
+  rectangles_integral.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_NEAR(result, 0.5, tolerance);
+  }
+}
+
+TEST(khovansky_d_rectangles_integral_mpi, test_multidimensional_integral_xy) {
+  boost::mpi::communicator world;
+  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 1.0}};
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        return args[0] * args[1];
+      });
+
+  auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+    task_data_mpi->inputs_count.emplace_back(bounds.size());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+    task_data_mpi->outputs_count.emplace_back(1);
+  }
+
+  khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi rectangles_integral(task_data_mpi);
+  ASSERT_EQ(rectangles_integral.ValidationImpl(), true);
+  rectangles_integral.PreProcessingImpl();
+  rectangles_integral.RunImpl();
+  rectangles_integral.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_NEAR(result, 0.25, tolerance);
+  }
+}
+
+TEST(khovansky_d_rectangles_integral_mpi, test_multidimensional_integral_xyz) {
+  boost::mpi::communicator world;
+  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        return args[0] * args[1] * args[2];
+      });
+
+  auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+    task_data_mpi->inputs_count.emplace_back(bounds.size());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+    task_data_mpi->outputs_count.emplace_back(1);
+  }
+
+  khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi rectangles_integral(task_data_mpi);
+  ASSERT_EQ(rectangles_integral.ValidationImpl(), true);
+  rectangles_integral.PreProcessingImpl();
+  rectangles_integral.RunImpl();
+  rectangles_integral.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_NEAR(result, 1.0 / 8, tolerance);
+  }
+}
+
+TEST(khovansky_d_rectangles_integral_mpi, test_integral_sum) {
+  boost::mpi::communicator world;
+  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 1.0}};
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        return args[0] + args[1];
+      });
+
+  auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+    task_data_mpi->inputs_count.emplace_back(bounds.size());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+    task_data_mpi->outputs_count.emplace_back(1);
+  }
+
+  khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi rectangles_integral(task_data_mpi);
+  ASSERT_EQ(rectangles_integral.ValidationImpl(), true);
+  rectangles_integral.PreProcessingImpl();
+  rectangles_integral.RunImpl();
+  rectangles_integral.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_NEAR(result, 1.0, tolerance);
+  }
+}
+
+TEST(khovansky_d_rectangles_integral_mpi, test_invalid_inputs) {
+  boost::mpi::communicator world;
+  auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_mpi->inputs_count.emplace_back(0);
+  }
+
+  khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi rectangles_integral(task_data_mpi);
+  ASSERT_EQ(rectangles_integral.ValidationImpl(), false);
+}
+
+TEST(khovansky_d_rectangles_integral_mpi, test_missing_inputs) {
+  boost::mpi::communicator world;
+  auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_mpi->inputs.emplace_back(nullptr);
+    task_data_mpi->inputs_count.emplace_back(1);
+  }
+
+  khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi rectangles_integral(task_data_mpi);
+  ASSERT_EQ(rectangles_integral.ValidationImpl(), false);
+}

--- a/tasks/mpi/khovansky_d_rectangles_integral/func_tests/main.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/func_tests/main.cpp
@@ -21,21 +21,14 @@ TEST(khovansky_d_rectangles_integral_mpi, test_integral_x) {
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-      std::vector<uint8_t> bounds_data(sizeof(std::pair<double, double>) * bounds.size());
-      std::memcpy(bounds_data.data(), bounds.data(), bounds_data.size());
-      task_data_mpi->inputs.emplace_back(bounds_data.data());
-      task_data_mpi->inputs_count.emplace_back(bounds.size());
-
-      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
-      task_data_mpi->inputs_count.emplace_back(1);
-
-      std::vector<uint8_t> func_data(sizeof(std::function<double(std::vector<double>)>));
-      std::memcpy(func_data.data(), func_ptr.get(), sizeof(std::function<double(std::vector<double>)>));
-      task_data_mpi->inputs.emplace_back(func_data.data());
-      task_data_mpi->inputs_count.emplace_back(func_data.size());
-
-      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
-      task_data_mpi->outputs_count.emplace_back(1);
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+    task_data_mpi->inputs_count.emplace_back(bounds.size());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+    task_data_mpi->outputs_count.emplace_back(1);
   }
 
   khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi rectangles_integral(task_data_mpi);
@@ -45,7 +38,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_integral_x) {
   rectangles_integral.PostProcessingImpl();
 
   if (world.rank() == 0) {
-      ASSERT_NEAR(result, 0.5, tolerance);
+    ASSERT_NEAR(result, 0.5, tolerance);
   }
 }
 
@@ -60,19 +53,12 @@ TEST(khovansky_d_rectangles_integral_mpi, test_multidimensional_integral_xy) {
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    std::vector<uint8_t> bounds_data(sizeof(std::pair<double, double>) * bounds.size());
-    std::memcpy(bounds_data.data(), bounds.data(), bounds_data.size());
-    task_data_mpi->inputs.emplace_back(bounds_data.data());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
     task_data_mpi->inputs_count.emplace_back(bounds.size());
-
     task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
     task_data_mpi->inputs_count.emplace_back(1);
-
-    std::vector<uint8_t> func_data(sizeof(std::function<double(std::vector<double>)>));
-    std::memcpy(func_data.data(), func_ptr.get(), sizeof(std::function<double(std::vector<double>)>));
-    task_data_mpi->inputs.emplace_back(func_data.data());
-    task_data_mpi->inputs_count.emplace_back(func_data.size());
-
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+    task_data_mpi->inputs_count.emplace_back(1);
     task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
     task_data_mpi->outputs_count.emplace_back(1);
   }
@@ -99,19 +85,12 @@ TEST(khovansky_d_rectangles_integral_mpi, test_multidimensional_integral_xyz) {
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    std::vector<uint8_t> bounds_data(sizeof(std::pair<double, double>) * bounds.size());
-    std::memcpy(bounds_data.data(), bounds.data(), bounds_data.size());
-    task_data_mpi->inputs.emplace_back(bounds_data.data());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
     task_data_mpi->inputs_count.emplace_back(bounds.size());
-
     task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
     task_data_mpi->inputs_count.emplace_back(1);
-
-    std::vector<uint8_t> func_data(sizeof(std::function<double(std::vector<double>)>));
-    std::memcpy(func_data.data(), func_ptr.get(), sizeof(std::function<double(std::vector<double>)>));
-    task_data_mpi->inputs.emplace_back(func_data.data());
-    task_data_mpi->inputs_count.emplace_back(func_data.size());
-
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+    task_data_mpi->inputs_count.emplace_back(1);
     task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
     task_data_mpi->outputs_count.emplace_back(1);
   }
@@ -138,19 +117,12 @@ TEST(khovansky_d_rectangles_integral_mpi, test_integral_sum) {
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    std::vector<uint8_t> bounds_data(sizeof(std::pair<double, double>) * bounds.size());
-    std::memcpy(bounds_data.data(), bounds.data(), bounds_data.size());
-    task_data_mpi->inputs.emplace_back(bounds_data.data());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
     task_data_mpi->inputs_count.emplace_back(bounds.size());
-
     task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
     task_data_mpi->inputs_count.emplace_back(1);
-
-    std::vector<uint8_t> func_data(sizeof(std::function<double(std::vector<double>)>));
-    std::memcpy(func_data.data(), func_ptr.get(), sizeof(std::function<double(std::vector<double>)>));
-    task_data_mpi->inputs.emplace_back(func_data.data());
-    task_data_mpi->inputs_count.emplace_back(func_data.size());
-
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+    task_data_mpi->inputs_count.emplace_back(1);
     task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
     task_data_mpi->outputs_count.emplace_back(1);
   }

--- a/tasks/mpi/khovansky_d_rectangles_integral/func_tests/main.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/func_tests/main.cpp
@@ -1,9 +1,10 @@
 #include <gtest/gtest.h>
 
 #include <boost/mpi/communicator.hpp>
-
+#include <cstdint>
+#include <functional>
 #include <memory>
-#include <random>
+#include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
@@ -16,9 +17,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_integral_x) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
-        return args[0];
-      });
+      [](const std::vector<double>& args) -> double { return args[0]; });
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
@@ -50,9 +49,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_multidimensional_integral_xy) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
-        return args[0] * args[1];
-      });
+      [](const std::vector<double>& args) -> double { return args[0] * args[1]; });
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
@@ -84,9 +81,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_multidimensional_integral_xyz) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
-        return args[0] * args[1] * args[2];
-      });
+      [](const std::vector<double>& args) -> double { return args[0] * args[1] * args[2]; });
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
@@ -118,9 +113,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_integral_sum) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
-        return args[0] + args[1];
-      });
+      [](const std::vector<double>& args) -> double { return args[0] + args[1]; });
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {

--- a/tasks/mpi/khovansky_d_rectangles_integral/func_tests/main.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/func_tests/main.cpp
@@ -17,7 +17,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_integral_x) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double { return args[0]; });
+      [](const std::vector<double> &args) -> double { return args[0]; });
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
@@ -49,7 +49,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_multidimensional_integral_xy) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double { return args[0] * args[1]; });
+      [](const std::vector<double> &args) -> double { return args[0] * args[1]; });
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
@@ -81,7 +81,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_multidimensional_integral_xyz) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double { return args[0] * args[1] * args[2]; });
+      [](const std::vector<double> &args) -> double { return args[0] * args[1] * args[2]; });
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
@@ -113,7 +113,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_integral_sum) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double { return args[0] + args[1]; });
+      [](const std::vector<double> &args) -> double { return args[0] + args[1]; });
 
   auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {

--- a/tasks/mpi/khovansky_d_rectangles_integral/include/ops_mpi.hpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/include/ops_mpi.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <functional>
+#include <vector>
+#include <cmath>
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/collectives.hpp>
+#include "core/task/include/task.hpp"
+
+namespace khovansky_d_rectangles_integral_mpi {
+
+class RectanglesIntegralSeq : public ppc::core::Task {
+ public:
+  explicit RectanglesIntegralSeq(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+ private:
+  double tolerance_;
+  double computed_result_{};
+  std::vector<std::pair<double, double>> bounds_;
+  std::function<double(std::vector<double>)> function_;
+};
+
+class RectanglesIntegralMpi : public ppc::core::Task {
+ public:
+  explicit RectanglesIntegralMpi(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)){}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+ private:
+  boost::mpi::communicator world_;
+  double tolerance_;
+  double computed_result_{};
+  std::vector<std::pair<double, double>> bounds_;
+  std::function<double(std::vector<double>)> function_;
+};
+
+}  // namespace khovansky_d_rectangles_integral_mpi

--- a/tasks/mpi/khovansky_d_rectangles_integral/include/ops_mpi.hpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/include/ops_mpi.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <functional>
-#include <vector>
-#include <cmath>
-#include <boost/mpi/communicator.hpp>
 #include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cmath>
+#include <functional>
+#include <utility>
+#include <vector>
+
 #include "core/task/include/task.hpp"
 
 namespace khovansky_d_rectangles_integral_mpi {
@@ -16,6 +18,7 @@ class RectanglesIntegralSeq : public ppc::core::Task {
   bool ValidationImpl() override;
   bool RunImpl() override;
   bool PostProcessingImpl() override;
+
  private:
   double tolerance_;
   double computed_result_{};
@@ -25,11 +28,12 @@ class RectanglesIntegralSeq : public ppc::core::Task {
 
 class RectanglesIntegralMpi : public ppc::core::Task {
  public:
-  explicit RectanglesIntegralMpi(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)){}
+  explicit RectanglesIntegralMpi(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
   bool PreProcessingImpl() override;
   bool ValidationImpl() override;
   bool RunImpl() override;
   bool PostProcessingImpl() override;
+
  private:
   boost::mpi::communicator world_;
   double tolerance_;

--- a/tasks/mpi/khovansky_d_rectangles_integral/perf_tests/main.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/perf_tests/main.cpp
@@ -1,0 +1,127 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "mpi/khovansky_d_rectangles_integral/include/ops_mpi.hpp"
+
+TEST(khovansky_d_rectangles_integral_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  constexpr int kNumRuns = 8000;
+
+  std::vector<std::pair<double, double>> bounds = {
+      {-100000000.0, 100000000.0}, 
+      {-100000000.0, 100000000.0}, 
+      {-100000000.0, 100000000.0}
+  };
+
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        double product = 1.0;
+        for (int i = 0; i < 9; ++i) {
+          product *= args[0] * args[1] * args[2];
+          product += std::sin(args[0] * args[1]) * std::cos(args[2] + 1);
+        }
+        return product;
+      });
+
+  auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+    task_data_mpi->inputs_count.emplace_back(bounds.size());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+    task_data_mpi->outputs_count.emplace_back(1);
+  }
+
+  auto test_task_parallel =
+      std::make_shared<khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi>(task_data_mpi);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = kNumRuns;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_parallel);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  if (world.rank() == 0) {
+    ASSERT_NEAR(result, 0.0, tolerance);
+  }
+}
+
+TEST(khovansky_d_rectangles_integral_mpi, test_task_run) {
+  boost::mpi::communicator world;
+  constexpr int kNumRuns = 3000000;
+
+  std::vector<std::pair<double, double>> bounds = {
+    {-100000000.0, 100000000.0}, 
+    {-100000000.0, 100000000.0}, 
+    {-100000000.0, 100000000.0}
+  };
+
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        double product = 1.0;
+        for (int i = 0; i < 9; ++i) {
+          product *= args[0] * args[1] * args[2];
+          product += std::sin(args[0] * args[1]) * std::cos(args[2] + 1);
+        }
+        return product;
+      });
+
+  auto task_data_mpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+    task_data_mpi->inputs_count.emplace_back(bounds.size());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+    task_data_mpi->outputs_count.emplace_back(1);
+  }
+
+  auto test_task_parallel =
+      std::make_shared<khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi>(task_data_mpi);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = kNumRuns;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_parallel);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  if (world.rank() == 0) {
+    ASSERT_NEAR(result, 0.0, tolerance);
+  }
+}

--- a/tasks/mpi/khovansky_d_rectangles_integral/perf_tests/main.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/perf_tests/main.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/tasks/mpi/khovansky_d_rectangles_integral/perf_tests/main.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/perf_tests/main.cpp
@@ -1,11 +1,11 @@
 #include <gtest/gtest.h>
 
 #include <boost/mpi/communicator.hpp>
-
 #include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
@@ -17,16 +17,13 @@ TEST(khovansky_d_rectangles_integral_mpi, test_pipeline_run) {
   constexpr int kNumRuns = 8000;
 
   std::vector<std::pair<double, double>> bounds = {
-      {-100000000.0, 100000000.0}, 
-      {-100000000.0, 100000000.0}, 
-      {-100000000.0, 100000000.0}
-  };
+      {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}};
 
   double tolerance = 1e-6;
   double result = 0.0;
 
-  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
+  auto func_ptr =
+      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double>& args) -> double {
         double product = 1.0;
         for (int i = 0; i < 9; ++i) {
           product *= args[0] * args[1] * args[2];
@@ -47,8 +44,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_pipeline_run) {
     task_data_mpi->outputs_count.emplace_back(1);
   }
 
-  auto test_task_parallel =
-      std::make_shared<khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi>(task_data_mpi);
+  auto test_task_parallel = std::make_shared<khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi>(task_data_mpi);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = kNumRuns;
@@ -74,16 +70,13 @@ TEST(khovansky_d_rectangles_integral_mpi, test_task_run) {
   constexpr int kNumRuns = 3000000;
 
   std::vector<std::pair<double, double>> bounds = {
-    {-100000000.0, 100000000.0}, 
-    {-100000000.0, 100000000.0}, 
-    {-100000000.0, 100000000.0}
-  };
+      {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}};
 
   double tolerance = 1e-6;
   double result = 0.0;
 
-  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
+  auto func_ptr =
+      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double>& args) -> double {
         double product = 1.0;
         for (int i = 0; i < 9; ++i) {
           product *= args[0] * args[1] * args[2];
@@ -104,8 +97,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_task_run) {
     task_data_mpi->outputs_count.emplace_back(1);
   }
 
-  auto test_task_parallel =
-      std::make_shared<khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi>(task_data_mpi);
+  auto test_task_parallel = std::make_shared<khovansky_d_rectangles_integral_mpi::RectanglesIntegralMpi>(task_data_mpi);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = kNumRuns;

--- a/tasks/mpi/khovansky_d_rectangles_integral/perf_tests/main.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/perf_tests/main.cpp
@@ -23,7 +23,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_pipeline_run) {
   double result = 0.0;
 
   auto func_ptr =
-      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double>& args) -> double {
+      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double> &args) -> double {
         double product = 1.0;
         for (int i = 0; i < 9; ++i) {
           product *= args[0] * args[1] * args[2];
@@ -76,7 +76,7 @@ TEST(khovansky_d_rectangles_integral_mpi, test_task_run) {
   double result = 0.0;
 
   auto func_ptr =
-      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double>& args) -> double {
+      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double> &args) -> double {
         double product = 1.0;
         for (int i = 0; i < 9; ++i) {
           product *= args[0] * args[1] * args[2];

--- a/tasks/mpi/khovansky_d_rectangles_integral/src/ops_mpi.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/src/ops_mpi.cpp
@@ -1,0 +1,173 @@
+#include "mpi/khovansky_d_rectangles_integral/include/ops_mpi.hpp"
+
+#include <functional>
+#include <vector>
+#include <cmath>
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/collectives.hpp>
+#include "core/task/include/task.hpp"
+
+namespace khovansky_d_rectangles_integral_mpi {
+
+bool RectanglesIntegralSeq::PreProcessingImpl() {
+  auto* ptr = reinterpret_cast<std::pair<double, double>*>(task_data->inputs[0]);
+  bounds_.assign(ptr, ptr + task_data->inputs_count[0]);
+  tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
+
+  auto func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
+  if (func_ptr) {
+    function_ = *func_ptr;
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+bool RectanglesIntegralSeq::ValidationImpl() {
+  if (!task_data) {
+    return false;
+  }
+
+  if (task_data->inputs[0] == nullptr && task_data->inputs_count[0] == 0) {
+    return false;
+  }
+
+  if (task_data->outputs[0] == nullptr) {
+    return false;
+  }
+
+  return task_data->inputs_count[0] > 0 && task_data->inputs.size() == 3 && task_data->outputs_count[0] == 1;
+}
+
+bool RectanglesIntegralSeq::RunImpl() {
+  size_t dim = bounds_.size();
+  std::vector<int> partitions(dim, 2);
+  std::vector<double> step(dim);
+  std::vector<double> variables(dim);
+
+  double integral = 0, prevIntegral;
+  
+  do {
+    prevIntegral = integral;
+    integral = 0;
+
+    for (size_t i = 0; i < dim; i++) {
+      step[i] = (bounds_[i].second - bounds_[i].first) / partitions[i];
+    }
+
+    std::vector<int> indices(dim, 0);
+    bool done = false;
+    while (!done) {
+      for (size_t i = 0; i < dim; i++) {
+        variables[i] = bounds_[i].first + (indices[i] + 0.5) * step[i];
+      }
+
+      integral += function_(variables);
+
+      size_t idx = 0;
+      while (idx < dim) {
+        indices[idx]++;
+        if (indices[idx] < partitions[idx]) {
+          break;
+        }
+        indices[idx] = 0;
+        idx++;
+      }
+      if (idx == dim) done = true;
+    }
+
+    double volume = 1.0;
+    for (size_t i = 0; i < dim; i++) {
+      volume *= step[i];
+      partitions[i] *= 2;
+    }
+
+    integral *= volume;
+  } while (std::abs(integral - prevIntegral) > tolerance_);
+
+  computed_result_ = integral;
+  return true;
+}
+
+bool RectanglesIntegralSeq::PostProcessingImpl() {
+  *reinterpret_cast<double*>(task_data->outputs[0]) = computed_result_;
+  return true;
+}
+
+bool RectanglesIntegralMpi::PreProcessingImpl() {
+  auto* ptr = reinterpret_cast<std::pair<double, double>*>(task_data->inputs[0]);
+  bounds_.assign(ptr, ptr + task_data->inputs_count[0]);
+  tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
+  auto func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
+  if (func_ptr) {
+    function_ = *func_ptr;
+  } else {
+    return false;
+  }
+  return true;
+}
+
+bool RectanglesIntegralMpi::ValidationImpl() {
+  if (!task_data || task_data->inputs_count[0] <= 0 || task_data->inputs.size() != 3 || task_data->outputs_count[0] != 1) {
+    return false;
+  }
+  return true;
+}
+
+bool RectanglesIntegralMpi::RunImpl() {
+  size_t dim = bounds_.size();
+  std::vector<int> partitions(dim, 2);
+  std::vector<double> step(dim);
+  std::vector<double> variables(dim);
+
+  double integral = 0, prevIntegral;
+  do {
+    prevIntegral = integral;
+    integral = 0;
+
+    for (size_t i = 0; i < dim; i++) {
+      step[i] = (bounds_[i].second - bounds_[i].first) / partitions[i];
+    }
+
+    std::vector<int> indices(dim, 0);
+    bool done = false;
+    while (!done) {
+      for (size_t i = 0; i < dim; i++) {
+        variables[i] = bounds_[i].first + (indices[i] + 0.5) * step[i];
+      }
+      integral += function_(variables);
+
+      size_t idx = 0;
+      while (idx < dim) {
+        indices[idx]++;
+        if (indices[idx] < partitions[idx]) {
+          break;
+        }
+        indices[idx] = 0;
+        idx++;
+      }
+      if (idx == dim) done = true;
+    }
+
+    double volume = 1.0;
+    for (size_t i = 0; i < dim; i++) {
+      volume *= step[i];
+      partitions[i] *= 2;
+    }
+
+    integral *= volume;
+  } while (std::abs(integral - prevIntegral) > tolerance_);
+
+  boost::mpi::reduce(world_, integral, computed_result_, std::plus<>(), 0);
+  return true;
+}
+
+bool RectanglesIntegralMpi::PostProcessingImpl() {
+  if (world_.rank() == 0) {
+    *reinterpret_cast<double*>(task_data->outputs[0]) = computed_result_;
+  }
+  return true;
+}
+
+}  // namespace khovansky_d_rectangles_integral_mpi

--- a/tasks/mpi/khovansky_d_rectangles_integral/src/ops_mpi.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/src/ops_mpi.cpp
@@ -101,16 +101,15 @@ bool RectanglesIntegralSeq::PostProcessingImpl() {
 }
 
 bool RectanglesIntegralMpi::PreProcessingImpl() {
-  auto* ptr = reinterpret_cast<std::pair<double, double>*>(task_data->inputs[0]);
-  bounds_.assign(ptr, ptr + task_data->inputs_count[0]);
-  tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
-  auto* func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
-  if (func_ptr != nullptr) {
-    function_ = *func_ptr;
-  } else {
-    return false;
-  }
-  return true;
+  if (!task_data || task_data->inputs.size() < 3) {
+        return false;
+    }
+    auto* bounds_ptr = reinterpret_cast<std::pair<double, double>*>(task_data->inputs[0]);
+    bounds_.assign(bounds_ptr, bounds_ptr + task_data->inputs_count[0]);
+    tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
+    function_ = *reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
+
+    return true;
 }
 
 bool RectanglesIntegralMpi::ValidationImpl() {

--- a/tasks/mpi/khovansky_d_rectangles_integral/src/ops_mpi.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/src/ops_mpi.cpp
@@ -101,15 +101,16 @@ bool RectanglesIntegralSeq::PostProcessingImpl() {
 }
 
 bool RectanglesIntegralMpi::PreProcessingImpl() {
-  if (!task_data || task_data->inputs.size() < 3) {
-        return false;
-    }
-    auto* bounds_ptr = reinterpret_cast<std::pair<double, double>*>(task_data->inputs[0]);
-    bounds_.assign(bounds_ptr, bounds_ptr + task_data->inputs_count[0]);
-    tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
-    function_ = *reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
-
-    return true;
+  auto* ptr = reinterpret_cast<std::pair<double, double>*>(task_data->inputs[0]);
+  bounds_.assign(ptr, ptr + task_data->inputs_count[0]);
+  tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
+  auto* func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
+  if (func_ptr != nullptr) {
+    function_ = *func_ptr;
+  } else {
+    return false;
+  }
+  return true;
 }
 
 bool RectanglesIntegralMpi::ValidationImpl() {

--- a/tasks/mpi/khovansky_d_rectangles_integral/src/ops_mpi.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/src/ops_mpi.cpp
@@ -16,7 +16,7 @@ bool RectanglesIntegralSeq::PreProcessingImpl() {
   bounds_.assign(ptr, ptr + task_data->inputs_count[0]);
   tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
 
-  auto *func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
+  auto* func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
   if (func_ptr != nullptr) {
     function_ = *func_ptr;
   } else {
@@ -49,10 +49,10 @@ bool RectanglesIntegralSeq::RunImpl() {
   std::vector<double> variables(dim);
 
   double integral = 0;
-  double prevIntegral = 0;
+  double prev_integral = 0;
 
   do {
-    prevIntegral = integral;
+    prev_integral = integral;
     integral = 0;
 
     for (size_t i = 0; i < dim; i++) {
@@ -89,7 +89,7 @@ bool RectanglesIntegralSeq::RunImpl() {
     }
 
     integral *= volume;
-  } while (std::abs(integral - prevIntegral) > tolerance_);
+  } while (std::abs(integral - prev_integral) > tolerance_);
 
   computed_result_ = integral;
   return true;
@@ -104,7 +104,7 @@ bool RectanglesIntegralMpi::PreProcessingImpl() {
   auto* ptr = reinterpret_cast<std::pair<double, double>*>(task_data->inputs[0]);
   bounds_.assign(ptr, ptr + task_data->inputs_count[0]);
   tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
-  auto *func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
+  auto* func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
   if (func_ptr != nullptr) {
     function_ = *func_ptr;
   } else {
@@ -114,8 +114,8 @@ bool RectanglesIntegralMpi::PreProcessingImpl() {
 }
 
 bool RectanglesIntegralMpi::ValidationImpl() {
-  return !(!task_data || task_data->inputs_count[0] <= 0 || task_data->inputs.size() != 3 ||
-      task_data->outputs_count[0] != 1);
+  return (task_data && task_data->inputs_count[0] > 0 && task_data->inputs.size() == 3 &&
+           task_data->outputs_count[0] == 1);
 }
 
 bool RectanglesIntegralMpi::RunImpl() {
@@ -125,10 +125,10 @@ bool RectanglesIntegralMpi::RunImpl() {
   std::vector<double> variables(dim);
 
   double integral = 0;
-  double prevIntegral =0;
+  double prev_integral = 0;
 
   do {
-    prevIntegral = integral;
+    prev_integral = integral;
     integral = 0;
 
     for (size_t i = 0; i < dim; i++) {
@@ -164,7 +164,7 @@ bool RectanglesIntegralMpi::RunImpl() {
     }
 
     integral *= volume;
-  } while (std::abs(integral - prevIntegral) > tolerance_);
+  } while (std::abs(integral - prev_integral) > tolerance_);
 
   boost::mpi::reduce(world_, integral, computed_result_, std::plus<>(), 0);
   return true;

--- a/tasks/mpi/khovansky_d_rectangles_integral/src/ops_mpi.cpp
+++ b/tasks/mpi/khovansky_d_rectangles_integral/src/ops_mpi.cpp
@@ -115,7 +115,7 @@ bool RectanglesIntegralMpi::PreProcessingImpl() {
 
 bool RectanglesIntegralMpi::ValidationImpl() {
   return (task_data && task_data->inputs_count[0] > 0 && task_data->inputs.size() == 3 &&
-           task_data->outputs_count[0] == 1);
+          task_data->outputs_count[0] == 1);
 }
 
 bool RectanglesIntegralMpi::RunImpl() {

--- a/tasks/seq/khovansky_d_rectangles_integral/func_tests/main.cpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/func_tests/main.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
@@ -13,9 +15,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_integral_x) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
-        return args[0];
-      });
+      [](const std::vector<double>& args) -> double { return args[0]; });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
@@ -42,9 +42,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_multidimensional_integral_xy) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
-        return args[0] * args[1];
-      });
+      [](const std::vector<double>& args) -> double { return args[0] * args[1]; });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
@@ -71,9 +69,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_multidimensional_integral_xyz) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
-        return args[0] * args[1] * args[2];
-      });
+      [](const std::vector<double>& args) -> double { return args[0] * args[1] * args[2]; });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
@@ -100,9 +96,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_symmetric_function) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
-        return args[0] * args[0];
-      });
+      [](const std::vector<double>& args) -> double { return args[0] * args[0]; });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
@@ -129,9 +123,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_integral_sum) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
-        return args[0] + args[1];
-      });
+      [](const std::vector<double>& args) -> double { return args[0] + args[1]; });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));

--- a/tasks/seq/khovansky_d_rectangles_integral/func_tests/main.cpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/func_tests/main.cpp
@@ -15,7 +15,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_integral_x) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double { return args[0]; });
+      [](const std::vector<double> &args) -> double { return args[0]; });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
@@ -42,7 +42,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_multidimensional_integral_xy) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double { return args[0] * args[1]; });
+      [](const std::vector<double> &args) -> double { return args[0] * args[1]; });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
@@ -69,7 +69,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_multidimensional_integral_xyz) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double { return args[0] * args[1] * args[2]; });
+      [](const std::vector<double> &args) -> double { return args[0] * args[1] * args[2]; });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));

--- a/tasks/seq/khovansky_d_rectangles_integral/func_tests/main.cpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/func_tests/main.cpp
@@ -96,7 +96,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_symmetric_function) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double { return args[0] * args[0]; });
+      [](const std::vector<double> &args) -> double { return args[0] * args[0]; });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
@@ -123,7 +123,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_integral_sum) {
   double result = 0.0;
 
   auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double { return args[0] + args[1]; });
+      [](const std::vector<double> &args) -> double { return args[0] + args[1]; });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));

--- a/tasks/seq/khovansky_d_rectangles_integral/func_tests/main.cpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/func_tests/main.cpp
@@ -1,0 +1,153 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "seq/khovansky_d_rectangles_integral/include/ops_seq.hpp"
+
+TEST(khovansky_d_rectangles_integral_seq, test_integral_x) {
+  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}};
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        return args[0];
+      });
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+  task_data_seq->inputs_count.emplace_back(bounds.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+  task_data_seq->outputs_count.emplace_back(1);
+
+  khovansky_d_rectangles_integral_seq::RectanglesIntegralSeq integral_task(task_data_seq);
+  ASSERT_EQ(integral_task.ValidationImpl(), true);
+  integral_task.PreProcessingImpl();
+  integral_task.RunImpl();
+  integral_task.PostProcessingImpl();
+
+  ASSERT_NEAR(result, 0.5, tolerance);
+}
+
+TEST(khovansky_d_rectangles_integral_seq, test_multidimensional_integral_xy) {
+  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 1.0}};
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        return args[0] * args[1];
+      });
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+  task_data_seq->inputs_count.emplace_back(bounds.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+  task_data_seq->outputs_count.emplace_back(1);
+
+  khovansky_d_rectangles_integral_seq::RectanglesIntegralSeq integral_task(task_data_seq);
+  ASSERT_EQ(integral_task.ValidationImpl(), true);
+  integral_task.PreProcessingImpl();
+  integral_task.RunImpl();
+  integral_task.PostProcessingImpl();
+
+  ASSERT_NEAR(result, 0.25, tolerance);
+}
+
+TEST(khovansky_d_rectangles_integral_seq, test_multidimensional_integral_xyz) {
+  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        return args[0] * args[1] * args[2];
+      });
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+  task_data_seq->inputs_count.emplace_back(bounds.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+  task_data_seq->outputs_count.emplace_back(1);
+
+  khovansky_d_rectangles_integral_seq::RectanglesIntegralSeq integral_task(task_data_seq);
+  ASSERT_EQ(integral_task.ValidationImpl(), true);
+  integral_task.PreProcessingImpl();
+  integral_task.RunImpl();
+  integral_task.PostProcessingImpl();
+
+  ASSERT_NEAR(result, 1.0 / 8, tolerance);
+}
+
+TEST(khovansky_d_rectangles_integral_seq, test_symmetric_function) {
+  std::vector<std::pair<double, double>> bounds = {{-1.0, 1.0}};
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        return args[0] * args[0];
+      });
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+  task_data_seq->inputs_count.emplace_back(bounds.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+  task_data_seq->outputs_count.emplace_back(1);
+
+  khovansky_d_rectangles_integral_seq::RectanglesIntegralSeq integral_task(task_data_seq);
+  ASSERT_EQ(integral_task.ValidationImpl(), true);
+  integral_task.PreProcessingImpl();
+  integral_task.RunImpl();
+  integral_task.PostProcessingImpl();
+
+  ASSERT_NEAR(result, 2.0 / 3, tolerance);
+}
+
+TEST(khovansky_d_rectangles_integral_seq, test_integral_sum) {
+  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 1.0}};
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        return args[0] + args[1];
+      });
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+  task_data_seq->inputs_count.emplace_back(bounds.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+  task_data_seq->outputs_count.emplace_back(1);
+
+  khovansky_d_rectangles_integral_seq::RectanglesIntegralSeq rectangles_integral(task_data_seq);
+  ASSERT_EQ(rectangles_integral.ValidationImpl(), true);
+  rectangles_integral.PreProcessingImpl();
+  rectangles_integral.RunImpl();
+  rectangles_integral.PostProcessingImpl();
+
+  ASSERT_NEAR(result, 1.0, tolerance);
+}

--- a/tasks/seq/khovansky_d_rectangles_integral/include/ops_seq.hpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/include/ops_seq.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <functional>
+#include <utility>
+#include <vector>
+
 #include "core/task/include/task.hpp"
 
 namespace khovansky_d_rectangles_integral_seq {
@@ -12,6 +15,7 @@ class RectanglesIntegralSeq : public ppc::core::Task {
   bool ValidationImpl() override;
   bool RunImpl() override;
   bool PostProcessingImpl() override;
+
  private:
   double tolerance_;
   double computed_result_{};

--- a/tasks/seq/khovansky_d_rectangles_integral/include/ops_seq.hpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/include/ops_seq.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <functional>
+#include "core/task/include/task.hpp"
+
+namespace khovansky_d_rectangles_integral_seq {
+
+class RectanglesIntegralSeq : public ppc::core::Task {
+ public:
+  explicit RectanglesIntegralSeq(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+ private:
+  double tolerance_;
+  double computed_result_{};
+  std::vector<std::pair<double, double>> bounds_;
+  std::function<double(std::vector<double>)> function_;
+};
+
+}  // namespace khovansky_d_rectangles_integral_seq

--- a/tasks/seq/khovansky_d_rectangles_integral/perf_tests/main.cpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/perf_tests/main.cpp
@@ -1,9 +1,13 @@
 #include <gtest/gtest.h>
+
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <utility>
 #include <vector>
+
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
 #include "seq/khovansky_d_rectangles_integral/include/ops_seq.hpp"
@@ -12,16 +16,13 @@ TEST(khovansky_d_rectangles_integral_seq, test_pipeline_run) {
   constexpr int kNumRuns = 8000;
 
   std::vector<std::pair<double, double>> bounds = {
-      {-100000000.0, 100000000.0}, 
-      {-100000000.0, 100000000.0}, 
-      {-100000000.0, 100000000.0}
-  };
+      {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}};
 
   double tolerance = 1e-6;
   double result = 0.0;
 
-  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-      [](const std::vector<double>& args) -> double {
+  auto func_ptr =
+      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double>& args) -> double {
         double product = 1.0;
         for (int i = 0; i < 9; ++i) {
           product *= args[0] * args[1] * args[2];
@@ -60,28 +61,24 @@ TEST(khovansky_d_rectangles_integral_seq, test_pipeline_run) {
   ASSERT_NEAR(result, 0.0, tolerance);
 }
 
-
 TEST(khovansky_d_rectangles_integral_seq, test_task_run) {
   constexpr int kNumRuns = 3000000;
 
   std::vector<std::pair<double, double>> bounds = {
-    {-100000000.0, 100000000.0}, 
-    {-100000000.0, 100000000.0}, 
-    {-100000000.0, 100000000.0}
-};
+    {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}};
 
-double tolerance = 1e-6;
-double result = 0.0;
+  double tolerance = 1e-6;
+  double result = 0.0;
 
-auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
-    [](const std::vector<double>& args) -> double {
-      double product = 1.0;
-      for (int i = 0; i < 9; ++i) {
-        product *= args[0] * args[1] * args[2];
-        product += std::sin(args[0] * args[1]) * std::cos(args[2] + 1);
-      }
-      return product;
-    });
+  auto func_ptr =
+      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double>& args) -> double {
+        double product = 1.0;
+        for (int i = 0; i < 9; ++i) {
+          product *= args[0] * args[1] * args[2];
+          product += std::sin(args[0] * args[1]) * std::cos(args[2] + 1);
+        }
+        return product;
+      });
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));

--- a/tasks/seq/khovansky_d_rectangles_integral/perf_tests/main.cpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/perf_tests/main.cpp
@@ -1,0 +1,114 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "seq/khovansky_d_rectangles_integral/include/ops_seq.hpp"
+
+TEST(khovansky_d_rectangles_integral_seq, test_pipeline_run) {
+  constexpr int kNumRuns = 8000;
+
+  std::vector<std::pair<double, double>> bounds = {
+      {-100000000.0, 100000000.0}, 
+      {-100000000.0, 100000000.0}, 
+      {-100000000.0, 100000000.0}
+  };
+
+  double tolerance = 1e-6;
+  double result = 0.0;
+
+  auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+      [](const std::vector<double>& args) -> double {
+        double product = 1.0;
+        for (int i = 0; i < 9; ++i) {
+          product *= args[0] * args[1] * args[2];
+          product += std::sin(args[0] * args[1]) * std::cos(args[2] + 1);
+        }
+        return product;
+      });
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+  task_data_seq->inputs_count.emplace_back(bounds.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+  task_data_seq->outputs_count.emplace_back(1);
+
+  auto test_task_sequential =
+      std::make_shared<khovansky_d_rectangles_integral_seq::RectanglesIntegralSeq>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = kNumRuns;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  ASSERT_NEAR(result, 0.0, tolerance);
+}
+
+
+TEST(khovansky_d_rectangles_integral_seq, test_task_run) {
+  constexpr int kNumRuns = 3000000;
+
+  std::vector<std::pair<double, double>> bounds = {
+    {-100000000.0, 100000000.0}, 
+    {-100000000.0, 100000000.0}, 
+    {-100000000.0, 100000000.0}
+};
+
+double tolerance = 1e-6;
+double result = 0.0;
+
+auto func_ptr = std::make_shared<std::function<double(std::vector<double>)>>(
+    [](const std::vector<double>& args) -> double {
+      double product = 1.0;
+      for (int i = 0; i < 9; ++i) {
+        product *= args[0] * args[1] * args[2];
+        product += std::sin(args[0] * args[1]) * std::cos(args[2] + 1);
+      }
+      return product;
+    });
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(bounds.data()));
+  task_data_seq->inputs_count.emplace_back(bounds.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&tolerance));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(func_ptr.get()));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(&result));
+  task_data_seq->outputs_count.emplace_back(1);
+
+  auto test_task_sequential =
+      std::make_shared<khovansky_d_rectangles_integral_seq::RectanglesIntegralSeq>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = kNumRuns;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  ASSERT_NEAR(result, 0.0, tolerance);
+}

--- a/tasks/seq/khovansky_d_rectangles_integral/perf_tests/main.cpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/perf_tests/main.cpp
@@ -22,7 +22,7 @@ TEST(khovansky_d_rectangles_integral_seq, test_pipeline_run) {
   double result = 0.0;
 
   auto func_ptr =
-      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double>& args) -> double {
+      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double> &args) -> double {
         double product = 1.0;
         for (int i = 0; i < 9; ++i) {
           product *= args[0] * args[1] * args[2];
@@ -65,13 +65,12 @@ TEST(khovansky_d_rectangles_integral_seq, test_task_run) {
   constexpr int kNumRuns = 3000000;
 
   std::vector<std::pair<double, double>> bounds = {
-    {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}};
+      {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}, {-100000000.0, 100000000.0}};
 
   double tolerance = 1e-6;
   double result = 0.0;
-
   auto func_ptr =
-      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double>& args) -> double {
+      std::make_shared<std::function<double(std::vector<double>)>>([](const std::vector<double> &args) -> double {
         double product = 1.0;
         for (int i = 0; i < 9; ++i) {
           product *= args[0] * args[1] * args[2];

--- a/tasks/seq/khovansky_d_rectangles_integral/src/ops_seq.cpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/src/ops_seq.cpp
@@ -1,6 +1,9 @@
 #include "seq/khovansky_d_rectangles_integral/include/ops_seq.hpp"
 
 #include <cmath>
+#include <cstddef>
+#include <functional>
+#include <utility>
 #include <vector>
 
 namespace khovansky_d_rectangles_integral_seq {
@@ -10,8 +13,8 @@ bool RectanglesIntegralSeq::PreProcessingImpl() {
   bounds_.assign(ptr, ptr + task_data->inputs_count[0]);
   tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
 
-  auto func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
-  if (func_ptr) {
+  auto *func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
+  if (func_ptr != nullptr) {
     function_ = *func_ptr;
   } else {
     return false;
@@ -42,8 +45,9 @@ bool RectanglesIntegralSeq::RunImpl() {
   std::vector<double> step(dim);
   std::vector<double> variables(dim);
 
-  double integral = 0, prevIntegral;
-  
+  double integral = 0;
+  double prevIntegral = 0;
+
   do {
     prevIntegral = integral;
     integral = 0;
@@ -70,7 +74,9 @@ bool RectanglesIntegralSeq::RunImpl() {
         indices[idx] = 0;
         idx++;
       }
-      if (idx == dim) done = true;
+      if (idx == dim) {
+        done = true;
+      }
     }
 
     double volume = 1.0;

--- a/tasks/seq/khovansky_d_rectangles_integral/src/ops_seq.cpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/src/ops_seq.cpp
@@ -12,8 +12,7 @@ bool RectanglesIntegralSeq::PreProcessingImpl() {
   auto* ptr = reinterpret_cast<std::pair<double, double>*>(task_data->inputs[0]);
   bounds_.assign(ptr, ptr + task_data->inputs_count[0]);
   tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
-
-  auto *func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
+  auto* func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
   if (func_ptr != nullptr) {
     function_ = *func_ptr;
   } else {
@@ -46,10 +45,10 @@ bool RectanglesIntegralSeq::RunImpl() {
   std::vector<double> variables(dim);
 
   double integral = 0;
-  double prevIntegral = 0;
+  double prev_integral = 0;
 
   do {
-    prevIntegral = integral;
+    prev_integral = integral;
     integral = 0;
 
     for (size_t i = 0; i < dim; i++) {
@@ -86,7 +85,7 @@ bool RectanglesIntegralSeq::RunImpl() {
     }
 
     integral *= volume;
-  } while (std::abs(integral - prevIntegral) > tolerance_);
+  } while (std::abs(integral - prev_integral) > tolerance_);
 
   computed_result_ = integral;
   return true;

--- a/tasks/seq/khovansky_d_rectangles_integral/src/ops_seq.cpp
+++ b/tasks/seq/khovansky_d_rectangles_integral/src/ops_seq.cpp
@@ -1,0 +1,94 @@
+#include "seq/khovansky_d_rectangles_integral/include/ops_seq.hpp"
+
+#include <cmath>
+#include <vector>
+
+namespace khovansky_d_rectangles_integral_seq {
+
+bool RectanglesIntegralSeq::PreProcessingImpl() {
+  auto* ptr = reinterpret_cast<std::pair<double, double>*>(task_data->inputs[0]);
+  bounds_.assign(ptr, ptr + task_data->inputs_count[0]);
+  tolerance_ = *reinterpret_cast<double*>(task_data->inputs[1]);
+
+  auto func_ptr = reinterpret_cast<std::function<double(std::vector<double>)>*>(task_data->inputs[2]);
+  if (func_ptr) {
+    function_ = *func_ptr;
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+bool RectanglesIntegralSeq::ValidationImpl() {
+  if (!task_data) {
+    return false;
+  }
+
+  if (task_data->inputs[0] == nullptr && task_data->inputs_count[0] == 0) {
+    return false;
+  }
+
+  if (task_data->outputs[0] == nullptr) {
+    return false;
+  }
+
+  return task_data->inputs_count[0] > 0 && task_data->inputs.size() == 3 && task_data->outputs_count[0] == 1;
+}
+
+bool RectanglesIntegralSeq::RunImpl() {
+  size_t dim = bounds_.size();
+  std::vector<int> partitions(dim, 2);
+  std::vector<double> step(dim);
+  std::vector<double> variables(dim);
+
+  double integral = 0, prevIntegral;
+  
+  do {
+    prevIntegral = integral;
+    integral = 0;
+
+    for (size_t i = 0; i < dim; i++) {
+      step[i] = (bounds_[i].second - bounds_[i].first) / partitions[i];
+    }
+
+    std::vector<int> indices(dim, 0);
+    bool done = false;
+    while (!done) {
+      for (size_t i = 0; i < dim; i++) {
+        variables[i] = bounds_[i].first + (indices[i] + 0.5) * step[i];
+      }
+
+      integral += function_(variables);
+
+      size_t idx = 0;
+      while (idx < dim) {
+        indices[idx]++;
+        if (indices[idx] < partitions[idx]) {
+          break;
+        }
+        indices[idx] = 0;
+        idx++;
+      }
+      if (idx == dim) done = true;
+    }
+
+    double volume = 1.0;
+    for (size_t i = 0; i < dim; i++) {
+      volume *= step[i];
+      partitions[i] *= 2;
+    }
+
+    integral *= volume;
+  } while (std::abs(integral - prevIntegral) > tolerance_);
+
+  computed_result_ = integral;
+  return true;
+}
+
+bool RectanglesIntegralSeq::PostProcessingImpl() {
+  *reinterpret_cast<double*>(task_data->outputs[0]) = computed_result_;
+  return true;
+}
+
+}  // namespace khovansky_d_rectangles_integral_seq


### PR DESCRIPTION
Описание программы: Вычисление многомерных интегралов методом прямоугольников
Программа предназначена для численного вычисления многомерных интегралов методом прямоугольников с пошаговым уточнением результата.

Последовательная версия
  1. Загружаются границы интегрирования, функция и требуемая точность.
  2. Область разбивается на равномерные прямоугольные элементы.
  3. Вычисляется сумма значений функции в центрах элементов.
  4. Количество разбиений увеличивается, пока разница между шагами не станет меньше заданной точности.
  5. Итоговое значение интеграла сохраняется в выходные данные.
  
Параллельная версия (MPI)
  1. Главный процесс делит область интегрирования между процессами.
  2. Каждый процесс вычисляет частичный интеграл на своем участке.
  3. Результаты объединяются с помощью MPI Reduce.
  4. Главный процесс сохраняет итоговый результат.